### PR TITLE
adapt BAIDU_RUNTIME openDataContext

### DIFF
--- a/baidugame/game.js
+++ b/baidugame/game.js
@@ -1,23 +1,26 @@
-require('libs/adapter/builtin/index.js');
-var Parser = require('libs/xmldom/dom-parser');
-window.DOMParser = Parser.DOMParser;
-require('libs/swan-downloader.js');
-require('src/settings');
-require('main');
-require('./libs/adapter/engine/Device');  // provide device related infos
-require('cocos2d-js');
-require('./libs/adapter/engine/index.js');
-swanDownloader.REMOTE_SERVER_ROOT = "";
-swanDownloader.SUBCONTEXT_ROOT = "";
-var pipeBeforeDownloader = cc.loader.md5Pipe || cc.loader.assetLoader;
-cc.loader.insertPipeAfter(pipeBeforeDownloader, swanDownloader);
+require('./libs/adapter/engine/Device.js');  // provide device related infos
+__device.init(function () {
+    require('libs/adapter/builtin/index.js');
+    var Parser = require('libs/xmldom/dom-parser.js');
+    window.DOMParser = Parser.DOMParser;
+    require('libs/swan-downloader.js');
+    require('src/settings.js');
+    require('main.js');
+    require('cocos2d-js.js');
+    require('./libs/adapter/engine/index.js');
 
-if (cc.sys.browserType === cc.sys.BROWSER_TYPE_BAIDU_GAME_SUB) {
-    require('./libs/sub-context-adapter');
-}
-else {
-    // Release Image objects after uploaded gl texture
-    cc.macro.CLEANUP_IMAGE_CACHE = true;
-}
+    swanDownloader.REMOTE_SERVER_ROOT = "";
+    swanDownloader.SUBCONTEXT_ROOT = "";
+    var pipeBeforeDownloader = cc.loader.md5Pipe || cc.loader.assetLoader;
+    cc.loader.insertPipeAfter(pipeBeforeDownloader, swanDownloader);
 
-window.boot();
+    if (cc.sys.browserType === cc.sys.BROWSER_TYPE_BAIDU_GAME_SUB) {
+        require('./libs/sub-context-adapter.js');
+    }
+    else {
+        // Release Image objects after uploaded gl texture
+        cc.macro.CLEANUP_IMAGE_CACHE = true;
+    }
+
+    window.boot();
+});

--- a/baidugame/libs/adapter/builtin/performance.js
+++ b/baidugame/libs/adapter/builtin/performance.js
@@ -4,16 +4,20 @@ import isDevtool from './util/isDevtool';
 let performance
 
 if (swan.getPerformance) {
-  const wxPerf = swan.getPerformance()
-  const initTime = wxPerf.now()
+  const swanPerf = swan.getPerformance()
+  const initTime = swanPerf.now()
 
-  const clientPerfAdapter = Object.assign({}, wxPerf, {
+  const clientPerfAdapter = Object.assign({}, swanPerf, {
     now: function() {
-      return (wxPerf.now() - initTime) / 1000
+      return (swanPerf.now() - initTime) / 1000
     }
   })
 
-  performance = isDevtool() ? wxPerf : clientPerfAdapter
+  performance = isDevtool() ? swanPerf : clientPerfAdapter
+}
+else {
+  performance = {};
+  performance.now = Date.now;
 }
 
 export default performance

--- a/baidugame/libs/adapter/builtin/window.js
+++ b/baidugame/libs/adapter/builtin/window.js
@@ -14,7 +14,7 @@ export { default as Worker } from './Worker'
 export { default as Image } from './Image'
 export { default as ImageBitmap } from './ImageBitmap'
 export { default as Audio } from './Audio'
-export { default as FileReader } from './FileReader'
+// export { default as FileReader } from './FileReader'  // TODO: FileReader adaption blocks in BAIDU_DEV_TOOL
 export { default as HTMLElement } from './HTMLElement'
 export { default as HTMLImageElement } from './HTMLImageElement'
 export { default as HTMLCanvasElement } from './HTMLCanvasElement'

--- a/baidugame/libs/adapter/engine/Device.js
+++ b/baidugame/libs/adapter/engine/Device.js
@@ -68,10 +68,34 @@ function initSystemInfo () {
     };
 }
 
-initSystemInfo();
-
-window.device = {
+window.__device = {
+    init (cb) {
+        initSystemInfo();
+        // send systemInfo to subDomain
+        if (swan.getOpenDataContext) {
+            swan.getOpenDataContext().postMessage({
+                fromAdapter: true,
+                event: 'systemInfo',
+                info: JSON.stringify(systemInfo),
+            });
+            cb && cb();
+        }
+        else {
+            swan.onMessage(function (data) {
+                if (data.fromAdapter) {
+                    if (data.event === 'systemInfo') {
+                        let info = JSON.parse(data.info);
+                        // info addon systemInfo
+                        Object.assign(info, systemInfo);
+                        Object.assign(systemInfo, info);
+                        
+                        cb && cb();
+                    }
+                }
+            });
+        }
+    },
     getSystemInfo () {
         return systemInfo;
-    },    
+    },
 };

--- a/baidugame/libs/adapter/engine/InputManager.js
+++ b/baidugame/libs/adapter/engine/InputManager.js
@@ -154,7 +154,7 @@ if (mgr) {
                 };
 
                 let registerTouchEvent;
-                if (sys.browserType === sys.BROWSER_TYPE_WECHAT_GAME_SUB) {
+                if (sys.browserType === sys.BROWSER_TYPE_BAIDU_GAME_SUB) {
                     _touchEventsMap = {
                         onTouchStart: _touchEventsMap.touchstart,
                         onTouchMove: _touchEventsMap.touchmove,
@@ -162,15 +162,16 @@ if (mgr) {
                         onTouchCancel: _touchEventsMap.touchcancel,
                     };
                     registerTouchEvent = function(eventName) {
-                        let handler = _touchEventsMap[eventName];
-                        wx[eventName](function(event) {
-                            if (!event.changedTouches) return;
-                            let pos = selfPointer.getHTMLElementPosition(element);
-                            let body = document.body;
-                            pos.left -= body.scrollLeft || 0;
-                            pos.top -= body.scrollTop || 0;
-                            handler(selfPointer.getTouchesByEvent(event, pos));
-                        });
+                        // TODO: adapt in BAIDU_DEV_TOOL 11.2 version
+                        // let handler = _touchEventsMap[eventName];
+                        // swan[eventName](function(event) {
+                        //     if (!event.changedTouches) return;
+                        //     let pos = selfPointer.getHTMLElementPosition(element);
+                        //     let body = document.body;
+                        //     pos.left -= body.scrollLeft || 0;
+                        //     pos.top -= body.scrollTop || 0;
+                        //     handler(selfPointer.getTouchesByEvent(event, pos));
+                        // });
                     };
                 }
                 else {
@@ -199,6 +200,10 @@ if (mgr) {
             }
 
             this._isRegisterEvent = true;
+        },
+
+        _registerKeyboardEvent () {
+            // baidu_game not support
         },
     });
 }

--- a/baidugame/libs/adapter/engine/Loader.js
+++ b/baidugame/libs/adapter/engine/Loader.js
@@ -33,7 +33,7 @@ function loadImage (item) {
 
     // load cc.Texture2D
     var rawUrl = item.rawUrl;
-    var tex = item.texture || new Texture2D();
+    var tex = item.texture || new cc.Texture2D();
     tex._uuid = item.uuid;
     tex.url = rawUrl;
     tex._setRawAsset(rawUrl, false);

--- a/baidugame/libs/sub-context-adapter.js
+++ b/baidugame/libs/sub-context-adapter.js
@@ -1,0 +1,73 @@
+var settings = window._CCSettings;
+
+cc.director.once(cc.Director.EVENT_BEFORE_SCENE_LOADING, function () {
+    cc.Pipeline.Downloader.PackDownloader._doPreload("BAIDU_SUBDOMAIN", settings.BAIDU_SUBDOMAIN_DATA);
+});
+
+var viewportInMain = {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0
+};
+
+// Touch conversion
+cc.view.convertToLocationInView = function (tx, ty, relatedPos, out) {
+    var result = out || cc.v2();
+    var x = this._devicePixelRatio * (tx - relatedPos.left);
+    var y = this._devicePixelRatio * (relatedPos.top + relatedPos.height - ty);
+    // Move to real viewport area
+    x = (x - viewportInMain.x) * this._viewportRect.width / viewportInMain.width;
+    y = (y - viewportInMain.y) * this._viewportRect.height / viewportInMain.height;
+    if (this._isRotated) {
+        result.x = this._viewportRect.width - y;
+        result.y = x;
+    }
+    else {
+        result.x = x;
+        result.y = y;
+    }
+    return result;
+};
+
+swan.onMessage(function (data) {
+    if (data.fromEngine) {
+        if (data.event === 'viewport') {
+            viewportInMain.x = data.x;
+            viewportInMain.y = data.y;
+            viewportInMain.width = data.width;
+            viewportInMain.height = data.height;
+        }
+    }
+});
+
+// Canvas component adaptation
+
+cc.Canvas.prototype.update = function () {
+    if (this._width !== cc.game.canvas.width || this._height !== cc.game.canvas.height) {
+        this.applySettings();
+    }
+};
+
+cc.Canvas.prototype.applySettings = function () {
+    var ResolutionPolicy = cc.ResolutionPolicy;
+    var policy;
+    if (this.fitHeight && this.fitWidth) {
+        policy = ResolutionPolicy.SHOW_ALL;
+    }
+    else {
+        if (this.fitWidth) {
+            policy = ResolutionPolicy.FIXED_WIDTH;
+        }
+        else if (this.fitHeight) {
+            policy = ResolutionPolicy.FIXED_HEIGHT;
+        }
+        else {
+            policy = ResolutionPolicy.NO_BORDER
+        }
+    }
+    var designRes = this._designResolution;
+    cc.view.setDesignResolutionSize(designRes.width, designRes.height, policy);
+    this._width = cc.game.canvas.width;
+    this._height = cc.game.canvas.height;
+};

--- a/baidugame/libs/swan-downloader.js
+++ b/baidugame/libs/swan-downloader.js
@@ -306,7 +306,7 @@ function downloadRemoteFile (item, callback) {
                 // check and mkdir remote folder has exists
                 ensureDirFor(localPath, function () {
                     // Save to local path
-                    swan.getFileSystemManager().saveFile({
+                    fs.saveFile({
                         tempFilePath: res.tempFilePath,
                         filePath: localPath,
                         success: function (res) {

--- a/baidugame/project.swan.json
+++ b/baidugame/project.swan.json
@@ -1,0 +1,14 @@
+{
+  "appid": "",
+  "compileType": "game",
+  "libVersion": "1.0.0",
+  "bundle":
+  {
+    "exclude": ["node_moudules"],
+    "entry": "game.js",
+    "compilers": [
+      {
+        "type": "babel"
+      }]
+  }
+}


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/866
适配百度开放数据域

说明：
- 目前开放数据域不支持触摸事件，需要等百度支持
- 开放数据域里不支持 swan.getSystemInfoSync，需要主域获取之后传入。所以这里 __device.init 需要异步回调，在获取 device 信息后，再初始化引擎
- 开放数据域的 performance.now 用 Date.now 实现
- FileReader 的适配会导致开放数据域的报错，暂时先注释掉。已经反馈给百度

关联：https://github.com/cocos-creator/engine/pull/3606