### PR TITLE
update deviceMotion adapting

### DIFF
--- a/baidugame/libs/adapter/engine/DeviceMotionEvent.js
+++ b/baidugame/libs/adapter/engine/DeviceMotionEvent.js
@@ -4,7 +4,6 @@ function DeviceMotionEvent() {
     this.accelerationIncludingGravity = null;
 }
 
-
 var registerFunc = _cc.inputManager._registerAccelerometerEvent.bind(_cc.inputManager);
 _cc.inputManager._registerAccelerometerEvent = function () {
   // register engine AccelerationEventListener to get acceleration data from wx
@@ -18,23 +17,23 @@ _cc.inputManager._registerAccelerometerEvent = function () {
     resCpy.z = res.z;
 
     var gravityFactor = 10;
+    var tmp = resCpy.x;
+    resCpy.x = resCpy.y;
+    resCpy.y = tmp;
+
     var systemInfo = swan.getSystemInfoSync();
     var windowWidth = systemInfo.windowWidth;
     var windowHeight = systemInfo.windowHeight;
     if (windowHeight < windowWidth) {
       // landscape view
-      var tmp = resCpy.x;
-      resCpy.x = resCpy.y;
-      resCpy.y = tmp;
-      
-      resCpy.x *= gravityFactor;
-      resCpy.y *= -gravityFactor;
+      resCpy.x *= -gravityFactor;
+      resCpy.y *= gravityFactor;
   
       // TODO adjust x y axis when the view flips upside down
     }
     else {
       // portrait view
-      resCpy.x *= -gravityFactor;
+      resCpy.x *= gravityFactor;
       resCpy.y *= -gravityFactor;
     }
     deviceMotionEvent.accelerationIncludingGravity = resCpy;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1088

changeLog:
- 修复百度小游戏 iOS 上重力感应方向问题

这个修复仍然不能解决屏幕翻转的问题，需要手百 11.9 版本里提供 `onDeviceOrientationChange` 接口支持