### PR TITLE
don't run mainLoop by default on sub context && add step event

### DIFF
--- a/baidugame/libs/sub-context-adapter.js
+++ b/baidugame/libs/sub-context-adapter.js
@@ -24,6 +24,24 @@ cc.view.convertToLocationInView = function (tx, ty, relatedPos, out) {
     return result;
 };
 
+// In sub context, run main loop after subContextView component get enabled.
+cc.game._prepareFinished = function (cb) {
+    this._prepared = true;
+
+    // Init engine
+    this._initEngine();
+    cc.AssetLibrary._loadBuiltins(() => {
+        // Log engine version
+        console.log('Cocos Creator v' + cc.ENGINE_VERSION);
+
+        this._setAnimFrame();
+        
+        this.emit(this.EVENT_GAME_INITED);
+
+        if (cb) cb();
+    });
+};
+
 swan.onMessage(function (data) {
     if (data.fromEngine) {
         if (data.event === 'viewport') {
@@ -42,6 +60,9 @@ swan.onMessage(function (data) {
         }
         else if (data.event === 'frameRate') {
             cc.game.setFrameRate(data.value);
+        }
+        else if (data.event === 'step') {
+            cc.game.step();
         }
     }
 });


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1504

changeLog:
- 引擎启动时，子域主循环默认不启动，等到主域里的 subcontextView 组件 enabled 了之后再启动
- 添加子域 step 事件，关联pr:  https://github.com/cocos-creator/engine/pull/4721